### PR TITLE
Implement merging rules for `mods` of `state.*` functions

### DIFF
--- a/conf/salt/saline.d/uyuni_merge_sls_sid.conf
+++ b/conf/salt/saline.d/uyuni_merge_sls_sid.conf
@@ -1,5 +1,10 @@
 rename_rules:
+  sid:
+    pxe.*: pxe*
+    mgr.*: mgr*
   sls:
     packages\.packages_.*: packages.packages*
     util\.systeminfo.*: util.systeminfo*
     util\.sync.*: util.sync*
+  mod:
+    \/var\/tmp\/.*\/salt_state.tgz: SALT-SSH-STATE-PKG


### PR DESCRIPTION
In some cases `mods` could be very different what's causing growing the metrics dramatically.
This implementation helps to avoid such situations.