### PR TITLE
Use mgr_origin_server instead of mgr_server for prometheus target

### DIFF
--- a/formulas/states/saline-prometheus/init.sls
+++ b/formulas/states/saline-prometheus/init.sls
@@ -4,7 +4,7 @@ saline-prometheus-cfg:
   - name: /etc/prometheus/saline.yml
   - contents: |
       - targets:
-        - {{ salt['pillar.get']('mgr_server') }}
+        - {{ salt['pillar.get']('mgr_origin_server') }}
         labels:
           __metrics_path__: {{ salt['pillar.get']('prometheus:saline_metrics_path') }}
 {%- if salt['pillar.get']('prometheus:saline_https_connection', False) %}

--- a/prometheus/saline-prometheus-config.sls
+++ b/prometheus/saline-prometheus-config.sls
@@ -3,7 +3,7 @@ saline-prometheus-cfg:
   - name: /etc/prometheus/saline.yml
   - contents: |
       - targets:
-        - {{ salt['pillar.get']('mgr_server') }}
+        - {{ salt['pillar.get']('mgr_origin_server') }}
         labels:
           __metrics_path__: /saline/metrics
           __scheme__: https


### PR DESCRIPTION
to avoid issues on deploying monitoring server behind the proxy (bsc#1246866)